### PR TITLE
Fix cpu-only install of pytorch

### DIFF
--- a/requirements-cpu.txt
+++ b/requirements-cpu.txt
@@ -1,5 +1,5 @@
+--extra-index-url https://download.pytorch.org/whl/cpu
 torch
 torchvision
--f https://download.pytorch.org/whl/cpu
 jupyterlab
 nbstripout


### PR DESCRIPTION
Previously the gpu (default) version of pytorch was installed, along with a bunch of cuda packages, which are large and take a while to download